### PR TITLE
Added Authors page

### DIFF
--- a/_layouts/authors.html
+++ b/_layouts/authors.html
@@ -1,0 +1,47 @@
+---
+title: "Authors"
+layout: default
+permalink: "/authors.html"
+---
+
+{% for auth in site.authors %}
+    {% assign author=auth[1] %}
+    <hr>
+
+    <div class="row post-top-meta">
+        <div class="col-xs-12 col-md-3 col-lg-2 text-center text-md-left mb-4 mb-md-0">
+            {% if author.avatar %}
+            <img class="author-thumb" src="{{ author.avatar| absolute_url }}" alt="{{ author.display_name }}">
+            {% else %}
+            <img class="author-thumb" src="https://www.gravatar.com/avatar/{{ author.gravatar }}?s=250&d=mm&r=x" alt="{{ author.display_name }}">
+            {% endif %}
+            <a target="_blank" href="
+            {% if author.follow %}
+            {{ author.follow }}
+            {% else %}
+            {{ author.web }}
+            {% endif %}"
+            class="btn follow">Follow</a>
+        </div>
+        <div class="col-xs-12 col-md-9 col-lg-10 text-center text-md-left">
+            <a target="_blank" class="link-dark" href="{{ author.web }}"><h6>{{ author.display_name }}</h6></a>
+            <span class="author-description">{{ author.description }}</span>
+        </div>
+    </div>
+
+    <section class="recent-posts">
+    <div class="row listrecent">
+
+    {% for post in site.posts %}
+
+    {% if post.author contains auth[0] %}
+
+        {% include postbox.html %}
+
+    {% endif %}
+
+    {% endfor %}
+    </div>
+    </section>
+
+{% endfor %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -87,6 +87,10 @@ ga('send', 'pageview');
                 </li>
 
                 <li class="nav-item">
+                    <a class="nav-link" href="{{ site.baseurl }}/authors">Authors</a>
+                    </li>
+                <li class="nav-item">
+
                 <a target="_blank" class="nav-link" href="https://www.instagram.com/algo.venture/"><i class="fab fa-instagram"></i> Follow </a>
                 </li>
 

--- a/_pages/authors.md
+++ b/_pages/authors.md
@@ -1,0 +1,5 @@
+---
+layout: authors
+title: Authors
+permalink: /authors
+---


### PR DESCRIPTION
Fixes #24 
Limitations:
* No pagination (not sure about this, since I am not sure how jekyll-paginator works)
* Forcibly lists all posts by the author. This is actually 2 sub-problems - **all** articles are listed (sheer volume), and that the viewer cannot unsee them.
* Doesn't hyperlink to a specific author, so linking to an author won't be possible.

However, in the current state of website these can be easily overloooked.  